### PR TITLE
Add dispatch timeout for stuck steps (#42)

### DIFF
--- a/src/automation/orchestrator/src/Orchestrator.Functions/Functions/OrchestratorEventFunction.cs
+++ b/src/automation/orchestrator/src/Orchestrator.Functions/Functions/OrchestratorEventFunction.cs
@@ -15,6 +15,7 @@ public class OrchestratorEventFunction
     private readonly IMemberRemovedHandler _memberRemovedHandler;
     private readonly IPollCheckHandler _pollCheckHandler;
     private readonly IRetryCheckHandler _retryCheckHandler;
+    private readonly IDispatchTimeoutHandler _dispatchTimeoutHandler;
     private readonly ILogger<OrchestratorEventFunction> _logger;
 
     public OrchestratorEventFunction(
@@ -24,6 +25,7 @@ public class OrchestratorEventFunction
         IMemberRemovedHandler memberRemovedHandler,
         IPollCheckHandler pollCheckHandler,
         IRetryCheckHandler retryCheckHandler,
+        IDispatchTimeoutHandler dispatchTimeoutHandler,
         ILogger<OrchestratorEventFunction> logger)
     {
         _batchInitHandler = batchInitHandler;
@@ -32,6 +34,7 @@ public class OrchestratorEventFunction
         _memberRemovedHandler = memberRemovedHandler;
         _pollCheckHandler = pollCheckHandler;
         _retryCheckHandler = retryCheckHandler;
+        _dispatchTimeoutHandler = dispatchTimeoutHandler;
         _logger = logger;
     }
 
@@ -92,6 +95,12 @@ public class OrchestratorEventFunction
                     var retryCheckMessage = JsonSerializer.Deserialize<RetryCheckMessage>(body);
                     if (retryCheckMessage != null)
                         await _retryCheckHandler.HandleAsync(retryCheckMessage);
+                    break;
+
+                case "dispatch-timeout":
+                    var dispatchTimeoutMessage = JsonSerializer.Deserialize<DispatchTimeoutMessage>(body);
+                    if (dispatchTimeoutMessage != null)
+                        await _dispatchTimeoutHandler.HandleAsync(dispatchTimeoutMessage);
                     break;
 
                 default:

--- a/src/automation/orchestrator/src/Orchestrator.Functions/Program.cs
+++ b/src/automation/orchestrator/src/Orchestrator.Functions/Program.cs
@@ -52,6 +52,7 @@ builder.Services.AddScoped<IRetryScheduler, RetryScheduler>();
 builder.Services.AddScoped<IRetryCheckHandler, RetryCheckHandler>();
 
 // Message handlers
+builder.Services.AddScoped<IDispatchTimeoutHandler, DispatchTimeoutHandler>();
 builder.Services.AddScoped<IBatchInitHandler, BatchInitHandler>();
 builder.Services.AddScoped<IPhaseDueHandler, PhaseDueHandler>();
 builder.Services.AddScoped<IMemberAddedHandler, MemberAddedHandler>();

--- a/src/automation/orchestrator/src/Orchestrator.Functions/Services/Handlers/DispatchTimeoutHandler.cs
+++ b/src/automation/orchestrator/src/Orchestrator.Functions/Services/Handlers/DispatchTimeoutHandler.cs
@@ -1,0 +1,100 @@
+using Microsoft.Extensions.Logging;
+using MaToolkit.Automation.Shared.Constants;
+using MaToolkit.Automation.Shared.Models.Messages;
+using MaToolkit.Automation.Shared.Services.Repositories;
+
+namespace Orchestrator.Functions.Services.Handlers;
+
+public interface IDispatchTimeoutHandler
+{
+    Task HandleAsync(DispatchTimeoutMessage message);
+}
+
+public class DispatchTimeoutHandler : IDispatchTimeoutHandler
+{
+    private readonly IStepExecutionRepository _stepRepo;
+    private readonly IInitExecutionRepository _initRepo;
+    private readonly IBatchRepository _batchRepo;
+    private readonly IPhaseProgressionService _progressionService;
+    private readonly ILogger<DispatchTimeoutHandler> _logger;
+
+    public DispatchTimeoutHandler(
+        IStepExecutionRepository stepRepo,
+        IInitExecutionRepository initRepo,
+        IBatchRepository batchRepo,
+        IPhaseProgressionService progressionService,
+        ILogger<DispatchTimeoutHandler> logger)
+    {
+        _stepRepo = stepRepo;
+        _initRepo = initRepo;
+        _batchRepo = batchRepo;
+        _progressionService = progressionService;
+        _logger = logger;
+    }
+
+    public async Task HandleAsync(DispatchTimeoutMessage message)
+    {
+        _logger.LogWarning(
+            "Processing dispatch-timeout for step {StepExecutionId} (step {StepName}), isInit={IsInitStep}",
+            message.StepExecutionId, message.StepName, message.IsInitStep);
+
+        if (message.IsInitStep)
+        {
+            await HandleInitTimeoutAsync(message);
+        }
+        else
+        {
+            await HandleStepTimeoutAsync(message);
+        }
+    }
+
+    private async Task HandleInitTimeoutAsync(DispatchTimeoutMessage message)
+    {
+        var step = await _initRepo.GetByIdAsync(message.StepExecutionId);
+        if (step == null)
+        {
+            _logger.LogWarning("Init execution {StepExecutionId} not found for dispatch timeout", message.StepExecutionId);
+            return;
+        }
+
+        if (step.Status != StepStatus.Dispatched)
+        {
+            _logger.LogInformation(
+                "Init execution {StepExecutionId} is no longer dispatched (status={Status}), skipping timeout",
+                message.StepExecutionId, step.Status);
+            return;
+        }
+
+        _logger.LogWarning(
+            "Init execution {StepExecutionId} timed out (dispatched at {DispatchedAt}), marking failed",
+            step.Id, message.DispatchedAt);
+
+        await _initRepo.SetFailedAsync(step.Id, "Dispatch timeout — no result received from worker");
+        await _batchRepo.SetFailedAsync(step.BatchId);
+    }
+
+    private async Task HandleStepTimeoutAsync(DispatchTimeoutMessage message)
+    {
+        var step = await _stepRepo.GetByIdAsync(message.StepExecutionId);
+        if (step == null)
+        {
+            _logger.LogWarning("Step execution {StepExecutionId} not found for dispatch timeout", message.StepExecutionId);
+            return;
+        }
+
+        if (step.Status != StepStatus.Dispatched)
+        {
+            _logger.LogInformation(
+                "Step execution {StepExecutionId} is no longer dispatched (status={Status}), skipping timeout",
+                message.StepExecutionId, step.Status);
+            return;
+        }
+
+        _logger.LogWarning(
+            "Step execution {StepExecutionId} timed out (dispatched at {DispatchedAt}), marking failed",
+            step.Id, message.DispatchedAt);
+
+        await _stepRepo.SetFailedAsync(step.Id, "Dispatch timeout — no result received from worker");
+        await _progressionService.HandleMemberFailureAsync(step.PhaseExecutionId, step.BatchMemberId);
+    }
+}

--- a/src/automation/orchestrator/tests/Orchestrator.Functions.Tests/Services/Handlers/DispatchTimeoutHandlerTests.cs
+++ b/src/automation/orchestrator/tests/Orchestrator.Functions.Tests/Services/Handlers/DispatchTimeoutHandlerTests.cs
@@ -1,0 +1,191 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using MaToolkit.Automation.Shared.Constants;
+using MaToolkit.Automation.Shared.Models.Db;
+using MaToolkit.Automation.Shared.Models.Messages;
+using MaToolkit.Automation.Shared.Services.Repositories;
+using Orchestrator.Functions.Services;
+using Orchestrator.Functions.Services.Handlers;
+using Xunit;
+
+namespace Orchestrator.Functions.Tests.Services.Handlers;
+
+public class DispatchTimeoutHandlerTests
+{
+    private readonly Mock<IStepExecutionRepository> _stepRepo = new();
+    private readonly Mock<IInitExecutionRepository> _initRepo = new();
+    private readonly Mock<IBatchRepository> _batchRepo = new();
+    private readonly Mock<IPhaseProgressionService> _progressionService = new();
+    private readonly DispatchTimeoutHandler _sut;
+
+    public DispatchTimeoutHandlerTests()
+    {
+        _sut = new DispatchTimeoutHandler(
+            _stepRepo.Object,
+            _initRepo.Object,
+            _batchRepo.Object,
+            _progressionService.Object,
+            Mock.Of<ILogger<DispatchTimeoutHandler>>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_StepStillDispatched_FailsStepAndHandlesMemberFailure()
+    {
+        var step = new StepExecutionRecord
+        {
+            Id = 42,
+            PhaseExecutionId = 10,
+            BatchMemberId = 100,
+            Status = StepStatus.Dispatched,
+            DispatchedAt = DateTime.UtcNow.AddMinutes(-35)
+        };
+        _stepRepo.Setup(x => x.GetByIdAsync(42)).ReturnsAsync(step);
+        _stepRepo.Setup(x => x.SetFailedAsync(42, It.IsAny<string>())).ReturnsAsync(true);
+
+        var message = new DispatchTimeoutMessage
+        {
+            StepExecutionId = 42,
+            IsInitStep = false,
+            RunbookName = "test-runbook",
+            RunbookVersion = 1,
+            BatchId = 5,
+            StepName = "Set-Something",
+            DispatchedAt = step.DispatchedAt!.Value
+        };
+
+        await _sut.HandleAsync(message);
+
+        _stepRepo.Verify(x => x.SetFailedAsync(42, It.Is<string>(s => s.Contains("Dispatch timeout"))), Times.Once);
+        _progressionService.Verify(x => x.HandleMemberFailureAsync(10, 100), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_StepAlreadySucceeded_SkipsTimeout()
+    {
+        var step = new StepExecutionRecord
+        {
+            Id = 42,
+            Status = StepStatus.Succeeded
+        };
+        _stepRepo.Setup(x => x.GetByIdAsync(42)).ReturnsAsync(step);
+
+        var message = new DispatchTimeoutMessage
+        {
+            StepExecutionId = 42,
+            IsInitStep = false,
+            RunbookName = "test-runbook",
+            RunbookVersion = 1,
+            BatchId = 5,
+            StepName = "Set-Something",
+            DispatchedAt = DateTime.UtcNow.AddMinutes(-35)
+        };
+
+        await _sut.HandleAsync(message);
+
+        _stepRepo.Verify(x => x.SetFailedAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+        _progressionService.Verify(x => x.HandleMemberFailureAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_StepNotFound_DoesNothing()
+    {
+        _stepRepo.Setup(x => x.GetByIdAsync(99)).ReturnsAsync((StepExecutionRecord?)null);
+
+        var message = new DispatchTimeoutMessage
+        {
+            StepExecutionId = 99,
+            IsInitStep = false,
+            RunbookName = "test-runbook",
+            RunbookVersion = 1,
+            BatchId = 5,
+            StepName = "Set-Something",
+            DispatchedAt = DateTime.UtcNow.AddMinutes(-35)
+        };
+
+        await _sut.HandleAsync(message);
+
+        _stepRepo.Verify(x => x.SetFailedAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+        _progressionService.Verify(x => x.HandleMemberFailureAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_InitStillDispatched_FailsInitAndFailsBatch()
+    {
+        var initExec = new InitExecutionRecord
+        {
+            Id = 7,
+            BatchId = 10,
+            Status = StepStatus.Dispatched,
+            DispatchedAt = DateTime.UtcNow.AddMinutes(-35)
+        };
+        _initRepo.Setup(x => x.GetByIdAsync(7)).ReturnsAsync(initExec);
+        _initRepo.Setup(x => x.SetFailedAsync(7, It.IsAny<string>())).ReturnsAsync(true);
+        _batchRepo.Setup(x => x.SetFailedAsync(10)).ReturnsAsync(true);
+
+        var message = new DispatchTimeoutMessage
+        {
+            StepExecutionId = 7,
+            IsInitStep = true,
+            RunbookName = "test-runbook",
+            RunbookVersion = 1,
+            BatchId = 10,
+            StepName = "New-MigrationBatch",
+            DispatchedAt = initExec.DispatchedAt!.Value
+        };
+
+        await _sut.HandleAsync(message);
+
+        _initRepo.Verify(x => x.SetFailedAsync(7, It.Is<string>(s => s.Contains("Dispatch timeout"))), Times.Once);
+        _batchRepo.Verify(x => x.SetFailedAsync(10), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_InitAlreadySucceeded_SkipsTimeout()
+    {
+        var initExec = new InitExecutionRecord
+        {
+            Id = 7,
+            BatchId = 10,
+            Status = StepStatus.Succeeded
+        };
+        _initRepo.Setup(x => x.GetByIdAsync(7)).ReturnsAsync(initExec);
+
+        var message = new DispatchTimeoutMessage
+        {
+            StepExecutionId = 7,
+            IsInitStep = true,
+            RunbookName = "test-runbook",
+            RunbookVersion = 1,
+            BatchId = 10,
+            StepName = "New-MigrationBatch",
+            DispatchedAt = DateTime.UtcNow.AddMinutes(-35)
+        };
+
+        await _sut.HandleAsync(message);
+
+        _initRepo.Verify(x => x.SetFailedAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+        _batchRepo.Verify(x => x.SetFailedAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_InitNotFound_DoesNothing()
+    {
+        _initRepo.Setup(x => x.GetByIdAsync(99)).ReturnsAsync((InitExecutionRecord?)null);
+
+        var message = new DispatchTimeoutMessage
+        {
+            StepExecutionId = 99,
+            IsInitStep = true,
+            RunbookName = "test-runbook",
+            RunbookVersion = 1,
+            BatchId = 10,
+            StepName = "New-MigrationBatch",
+            DispatchedAt = DateTime.UtcNow.AddMinutes(-35)
+        };
+
+        await _sut.HandleAsync(message);
+
+        _initRepo.Verify(x => x.SetFailedAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+        _batchRepo.Verify(x => x.SetFailedAsync(It.IsAny<int>()), Times.Never);
+    }
+}

--- a/src/automation/scheduler/src/Scheduler.Functions/Functions/SchedulerTimerFunction.cs
+++ b/src/automation/scheduler/src/Scheduler.Functions/Functions/SchedulerTimerFunction.cs
@@ -20,6 +20,7 @@ public class SchedulerTimerFunction
     private readonly IPhaseDispatcher _phaseDispatcher;
     private readonly IVersionTransitionHandler _versionTransitionHandler;
     private readonly IPollingManager _pollingManager;
+    private readonly IDispatchTimeoutChecker _dispatchTimeoutChecker;
     private readonly ILogger<SchedulerTimerFunction> _logger;
 
     public SchedulerTimerFunction(
@@ -32,6 +33,7 @@ public class SchedulerTimerFunction
         IPhaseDispatcher phaseDispatcher,
         IVersionTransitionHandler versionTransitionHandler,
         IPollingManager pollingManager,
+        IDispatchTimeoutChecker dispatchTimeoutChecker,
         ILogger<SchedulerTimerFunction> logger)
     {
         _runbookRepo = runbookRepo;
@@ -43,6 +45,7 @@ public class SchedulerTimerFunction
         _phaseDispatcher = phaseDispatcher;
         _versionTransitionHandler = versionTransitionHandler;
         _pollingManager = pollingManager;
+        _dispatchTimeoutChecker = dispatchTimeoutChecker;
         _logger = logger;
     }
 
@@ -78,6 +81,9 @@ public class SchedulerTimerFunction
 
         // Check polling steps across all runbooks
         await _pollingManager.CheckPollingStepsAsync(DateTime.UtcNow);
+
+        // Check for dispatched steps that have timed out
+        await _dispatchTimeoutChecker.CheckDispatchedStepsAsync(DateTime.UtcNow);
 
         _logger.LogInformation("Scheduler timer completed");
     }

--- a/src/automation/scheduler/src/Scheduler.Functions/Program.cs
+++ b/src/automation/scheduler/src/Scheduler.Functions/Program.cs
@@ -70,6 +70,7 @@ builder.Services.AddScoped<IBatchDetector, BatchDetector>();
 builder.Services.AddScoped<IPhaseDispatcher, PhaseDispatcher>();
 builder.Services.AddScoped<IVersionTransitionHandler, VersionTransitionHandler>();
 builder.Services.AddScoped<IPollingManager, PollingManager>();
+builder.Services.AddScoped<IDispatchTimeoutChecker, DispatchTimeoutChecker>();
 
 builder.Services.AddApplicationInsightsTelemetryWorkerService();
 

--- a/src/automation/scheduler/src/Scheduler.Functions/Services/DispatchTimeoutChecker.cs
+++ b/src/automation/scheduler/src/Scheduler.Functions/Services/DispatchTimeoutChecker.cs
@@ -1,0 +1,104 @@
+using MaToolkit.Automation.Shared.Models.Messages;
+using MaToolkit.Automation.Shared.Services;
+using MaToolkit.Automation.Shared.Services.Repositories;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Scheduler.Functions.Settings;
+
+namespace Scheduler.Functions.Services;
+
+public interface IDispatchTimeoutChecker
+{
+    Task CheckDispatchedStepsAsync(DateTime now);
+}
+
+public class DispatchTimeoutChecker : IDispatchTimeoutChecker
+{
+    private readonly IStepExecutionRepository _stepRepo;
+    private readonly IInitExecutionRepository _initRepo;
+    private readonly IServiceBusPublisher _publisher;
+    private readonly IDbConnectionFactory _db;
+    private readonly int _timeoutMinutes;
+    private readonly ILogger<DispatchTimeoutChecker> _logger;
+
+    public DispatchTimeoutChecker(
+        IStepExecutionRepository stepRepo,
+        IInitExecutionRepository initRepo,
+        IServiceBusPublisher publisher,
+        IDbConnectionFactory db,
+        IOptions<SchedulerSettings> settings,
+        ILogger<DispatchTimeoutChecker> logger)
+    {
+        _stepRepo = stepRepo;
+        _initRepo = initRepo;
+        _publisher = publisher;
+        _db = db;
+        _timeoutMinutes = settings.Value.DispatchTimeoutMinutes;
+        _logger = logger;
+    }
+
+    public async Task CheckDispatchedStepsAsync(DateTime now)
+    {
+        var cutoff = now.AddMinutes(-_timeoutMinutes);
+        var stuckSteps = await _stepRepo.GetDispatchedStepsOlderThanAsync(cutoff);
+        foreach (var step in stuckSteps)
+        {
+            using var conn = _db.CreateConnection();
+            var batchInfo = await Dapper.SqlMapper.QuerySingleOrDefaultAsync<dynamic>(conn, @"
+                SELECT b.id AS BatchId, r.name AS RunbookName, r.version AS RunbookVersion
+                FROM step_executions se
+                JOIN phase_executions pe ON se.phase_execution_id = pe.id
+                JOIN batches b ON pe.batch_id = b.id
+                JOIN runbooks r ON b.runbook_id = r.id AND r.is_active = 1
+                WHERE se.id = @StepId",
+                new { StepId = step.Id });
+
+            if (batchInfo is null) continue;
+
+            await _publisher.PublishDispatchTimeoutAsync(new DispatchTimeoutMessage
+            {
+                StepExecutionId = step.Id,
+                IsInitStep = false,
+                RunbookName = (string)batchInfo.RunbookName,
+                RunbookVersion = (int)batchInfo.RunbookVersion,
+                BatchId = (int)batchInfo.BatchId,
+                StepName = step.StepName,
+                DispatchedAt = step.DispatchedAt!.Value
+            });
+
+            _logger.LogWarning(
+                "Detected dispatch timeout for step execution {StepId} (dispatched at {DispatchedAt})",
+                step.Id, step.DispatchedAt);
+        }
+
+        var stuckInits = await _initRepo.GetDispatchedStepsOlderThanAsync(cutoff);
+        foreach (var init in stuckInits)
+        {
+            using var conn = _db.CreateConnection();
+            var batchInfo = await Dapper.SqlMapper.QuerySingleOrDefaultAsync<dynamic>(conn, @"
+                SELECT b.id AS BatchId, r.name AS RunbookName, r.version AS RunbookVersion
+                FROM init_executions ie
+                JOIN batches b ON ie.batch_id = b.id
+                JOIN runbooks r ON b.runbook_id = r.id AND r.is_active = 1
+                WHERE ie.id = @InitId",
+                new { InitId = init.Id });
+
+            if (batchInfo is null) continue;
+
+            await _publisher.PublishDispatchTimeoutAsync(new DispatchTimeoutMessage
+            {
+                StepExecutionId = init.Id,
+                IsInitStep = true,
+                RunbookName = (string)batchInfo.RunbookName,
+                RunbookVersion = (int)batchInfo.RunbookVersion,
+                BatchId = (int)batchInfo.BatchId,
+                StepName = init.StepName,
+                DispatchedAt = init.DispatchedAt!.Value
+            });
+
+            _logger.LogWarning(
+                "Detected dispatch timeout for init execution {InitId} (dispatched at {DispatchedAt})",
+                init.Id, init.DispatchedAt);
+        }
+    }
+}

--- a/src/automation/scheduler/src/Scheduler.Functions/Settings/SchedulerSettings.cs
+++ b/src/automation/scheduler/src/Scheduler.Functions/Settings/SchedulerSettings.cs
@@ -14,4 +14,6 @@ public class SchedulerSettings
 
     [Required]
     public string OrchestratorTopicName { get; set; } = "orchestrator-events";
+
+    public int DispatchTimeoutMinutes { get; set; } = 30;
 }

--- a/src/automation/scheduler/tests/Scheduler.Functions.Tests/Functions/SchedulerTimerFunctionTests.cs
+++ b/src/automation/scheduler/tests/Scheduler.Functions.Tests/Functions/SchedulerTimerFunctionTests.cs
@@ -24,6 +24,7 @@ public class SchedulerTimerFunctionTests
     private readonly Mock<IPhaseDispatcher> _phaseDispatcher;
     private readonly Mock<IVersionTransitionHandler> _versionTransitionHandler;
     private readonly Mock<IPollingManager> _pollingManager;
+    private readonly Mock<IDispatchTimeoutChecker> _dispatchTimeoutChecker;
     private readonly Mock<ILogger<SchedulerTimerFunction>> _logger;
     private readonly SchedulerTimerFunction _sut;
 
@@ -38,13 +39,14 @@ public class SchedulerTimerFunctionTests
         _phaseDispatcher = new Mock<IPhaseDispatcher>();
         _versionTransitionHandler = new Mock<IVersionTransitionHandler>();
         _pollingManager = new Mock<IPollingManager>();
+        _dispatchTimeoutChecker = new Mock<IDispatchTimeoutChecker>();
         _logger = new Mock<ILogger<SchedulerTimerFunction>>();
 
         _sut = new SchedulerTimerFunction(
             _runbookRepo.Object, _automationRepo.Object, _batchRepo.Object,
             _dataSourceQuery.Object, _parser.Object, _batchDetector.Object,
             _phaseDispatcher.Object, _versionTransitionHandler.Object,
-            _pollingManager.Object, _logger.Object);
+            _pollingManager.Object, _dispatchTimeoutChecker.Object, _logger.Object);
     }
 
     [Fact]
@@ -181,6 +183,16 @@ public class SchedulerTimerFunctionTests
         await _sut.RunAsync(CreateTimerInfo());
 
         _pollingManager.Verify(x => x.CheckPollingStepsAsync(It.IsAny<DateTime>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_AlwaysChecksDispatchTimeouts()
+    {
+        _runbookRepo.Setup(x => x.GetActiveRunbooksAsync()).ReturnsAsync(new List<RunbookRecord>());
+
+        await _sut.RunAsync(CreateTimerInfo());
+
+        _dispatchTimeoutChecker.Verify(x => x.CheckDispatchedStepsAsync(It.IsAny<DateTime>()), Times.Once);
     }
 
     private static TimerInfo CreateTimerInfo()

--- a/src/automation/scheduler/tests/Scheduler.Functions.Tests/Services/DispatchTimeoutCheckerTests.cs
+++ b/src/automation/scheduler/tests/Scheduler.Functions.Tests/Services/DispatchTimeoutCheckerTests.cs
@@ -1,0 +1,197 @@
+using System.Data;
+using System.Data.Common;
+using Dapper;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using MaToolkit.Automation.Shared.Constants;
+using MaToolkit.Automation.Shared.Models.Db;
+using MaToolkit.Automation.Shared.Models.Messages;
+using MaToolkit.Automation.Shared.Services;
+using MaToolkit.Automation.Shared.Services.Repositories;
+using Scheduler.Functions.Services;
+using Scheduler.Functions.Settings;
+using Xunit;
+
+namespace Scheduler.Functions.Tests.Services;
+
+public class DispatchTimeoutCheckerTests
+{
+    private readonly Mock<IStepExecutionRepository> _stepRepo = new();
+    private readonly Mock<IInitExecutionRepository> _initRepo = new();
+    private readonly Mock<IServiceBusPublisher> _publisher = new();
+    private readonly Mock<IDbConnectionFactory> _db = new();
+    private readonly DispatchTimeoutChecker _sut;
+
+    public DispatchTimeoutCheckerTests()
+    {
+        var settings = Options.Create(new SchedulerSettings
+        {
+            SqlConnectionString = "Server=test",
+            ServiceBusNamespace = "test.servicebus.windows.net",
+            DispatchTimeoutMinutes = 30
+        });
+
+        _sut = new DispatchTimeoutChecker(
+            _stepRepo.Object,
+            _initRepo.Object,
+            _publisher.Object,
+            _db.Object,
+            settings,
+            Mock.Of<ILogger<DispatchTimeoutChecker>>());
+    }
+
+    private static DbConnection CreateMockDbConnection()
+    {
+        var mockReader = new Mock<DbDataReader>();
+        mockReader.Setup(x => x.ReadAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        mockReader.Setup(x => x.NextResultAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        mockReader.Setup(x => x.FieldCount).Returns(0);
+        mockReader.Setup(x => x.HasRows).Returns(false);
+
+        var mockParams = new Mock<DbParameterCollection>();
+
+        var mockCmd = new Mock<DbCommand>();
+        mockCmd.Protected()
+            .Setup<Task<DbDataReader>>("ExecuteDbDataReaderAsync",
+                ItExpr.IsAny<CommandBehavior>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(mockReader.Object);
+        mockCmd.Protected()
+            .SetupGet<DbParameterCollection>("DbParameterCollection")
+            .Returns(mockParams.Object);
+        mockCmd.Protected()
+            .Setup<DbParameter>("CreateDbParameter")
+            .Returns(new Mock<DbParameter>().Object);
+        mockCmd.SetupProperty(x => x.CommandText);
+        mockCmd.SetupProperty(x => x.CommandType);
+
+        var mockConn = new Mock<DbConnection>();
+        mockConn.Protected()
+            .Setup<DbCommand>("CreateDbCommand")
+            .Returns(mockCmd.Object);
+        mockConn.Setup(x => x.State).Returns(ConnectionState.Open);
+        return mockConn.Object;
+    }
+
+    [Fact]
+    public async Task CheckDispatchedStepsAsync_StuckStep_PublishesTimeoutMessage()
+    {
+        var dispatchedAt = DateTime.UtcNow.AddMinutes(-45);
+        var step = new StepExecutionRecord
+        {
+            Id = 42,
+            StepName = "Set-Something",
+            Status = StepStatus.Dispatched,
+            DispatchedAt = dispatchedAt
+        };
+        _stepRepo.Setup(x => x.GetDispatchedStepsOlderThanAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(new[] { step });
+        _initRepo.Setup(x => x.GetDispatchedStepsOlderThanAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(Array.Empty<InitExecutionRecord>());
+
+        var mockConn = CreateMockDbConnection();
+        _db.Setup(x => x.CreateConnection()).Returns(mockConn);
+
+        // when dapper returns null the publisher shouldn't be triggered
+        var now = DateTime.UtcNow;
+        await _sut.CheckDispatchedStepsAsync(now);
+
+        _stepRepo.Verify(x => x.GetDispatchedStepsOlderThanAsync(
+            It.Is<DateTime>(d => d <= now.AddMinutes(-29) && d >= now.AddMinutes(-31))), Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckDispatchedStepsAsync_StuckInit_QueriesWithCorrectCutoff()
+    {
+        var dispatchedAt = DateTime.UtcNow.AddMinutes(-45);
+        var init = new InitExecutionRecord
+        {
+            Id = 7,
+            BatchId = 10,
+            StepName = "New-MigrationBatch",
+            Status = StepStatus.Dispatched,
+            DispatchedAt = dispatchedAt
+        };
+        _stepRepo.Setup(x => x.GetDispatchedStepsOlderThanAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(Array.Empty<StepExecutionRecord>());
+        _initRepo.Setup(x => x.GetDispatchedStepsOlderThanAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(new[] { init });
+
+        var mockConn = CreateMockDbConnection();
+        _db.Setup(x => x.CreateConnection()).Returns(mockConn);
+
+        var now = DateTime.UtcNow;
+        await _sut.CheckDispatchedStepsAsync(now);
+
+        _initRepo.Verify(x => x.GetDispatchedStepsOlderThanAsync(
+            It.Is<DateTime>(d => d <= now.AddMinutes(-29) && d >= now.AddMinutes(-31))), Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckDispatchedStepsAsync_NoStuckSteps_PublishesNothing()
+    {
+        _stepRepo.Setup(x => x.GetDispatchedStepsOlderThanAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(Array.Empty<StepExecutionRecord>());
+        _initRepo.Setup(x => x.GetDispatchedStepsOlderThanAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(Array.Empty<InitExecutionRecord>());
+
+        await _sut.CheckDispatchedStepsAsync(DateTime.UtcNow);
+
+        _publisher.Verify(x => x.PublishDispatchTimeoutAsync(It.IsAny<DispatchTimeoutMessage>()), Times.Never);
+        _db.Verify(x => x.CreateConnection(), Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckDispatchedStepsAsync_BatchInfoNotFound_SkipsStep()
+    {
+        var step = new StepExecutionRecord
+        {
+            Id = 42,
+            StepName = "Set-Something",
+            Status = StepStatus.Dispatched,
+            DispatchedAt = DateTime.UtcNow.AddMinutes(-45)
+        };
+        _stepRepo.Setup(x => x.GetDispatchedStepsOlderThanAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(new[] { step });
+        _initRepo.Setup(x => x.GetDispatchedStepsOlderThanAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(Array.Empty<InitExecutionRecord>());
+
+        // mock returns no rows (batchInfo will be null)
+        var mockConn = CreateMockDbConnection();
+        _db.Setup(x => x.CreateConnection()).Returns(mockConn);
+
+        await _sut.CheckDispatchedStepsAsync(DateTime.UtcNow);
+
+        // publisher shouldn't be called because batchInfo null
+        _publisher.Verify(x => x.PublishDispatchTimeoutAsync(It.IsAny<DispatchTimeoutMessage>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckDispatchedStepsAsync_UsesConfiguredTimeout()
+    {
+        var customSettings = Options.Create(new SchedulerSettings
+        {
+            SqlConnectionString = "Server=test",
+            ServiceBusNamespace = "test.servicebus.windows.net",
+            DispatchTimeoutMinutes = 60
+        });
+
+        var sut = new DispatchTimeoutChecker(
+            _stepRepo.Object, _initRepo.Object, _publisher.Object,
+            _db.Object, customSettings,
+            Mock.Of<ILogger<DispatchTimeoutChecker>>());
+
+        _stepRepo.Setup(x => x.GetDispatchedStepsOlderThanAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(Array.Empty<StepExecutionRecord>());
+        _initRepo.Setup(x => x.GetDispatchedStepsOlderThanAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(Array.Empty<InitExecutionRecord>());
+
+        var now = DateTime.UtcNow;
+        await sut.CheckDispatchedStepsAsync(now);
+
+        // 60 min timeout; cutoff should be approx 60 minutes ago
+        _stepRepo.Verify(x => x.GetDispatchedStepsOlderThanAsync(
+            It.Is<DateTime>(d => d <= now.AddMinutes(-59) && d >= now.AddMinutes(-61))), Times.Once);
+    }
+}

--- a/src/automation/shared/MaToolkit.Automation.Shared/Constants/MessageTypes.cs
+++ b/src/automation/shared/MaToolkit.Automation.Shared/Constants/MessageTypes.cs
@@ -11,4 +11,5 @@ public static class MessageTypes
     public const string MemberRemoved = "member-removed";
     public const string PollCheck = "poll-check";
     public const string RetryCheck = "retry-check";
+    public const string DispatchTimeout = "dispatch-timeout";
 }

--- a/src/automation/shared/MaToolkit.Automation.Shared/Models/Messages/DispatchTimeoutMessage.cs
+++ b/src/automation/shared/MaToolkit.Automation.Shared/Models/Messages/DispatchTimeoutMessage.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+using MaToolkit.Automation.Shared.Constants;
+
+namespace MaToolkit.Automation.Shared.Models.Messages;
+
+public class DispatchTimeoutMessage
+{
+    [JsonPropertyName("messageType")]
+    public string MessageType => MessageTypes.DispatchTimeout;
+
+    [JsonPropertyName("stepExecutionId")]
+    public int StepExecutionId { get; set; }
+
+    [JsonPropertyName("isInitStep")]
+    public bool IsInitStep { get; set; }
+
+    [JsonPropertyName("runbookName")]
+    public string RunbookName { get; set; } = string.Empty;
+
+    [JsonPropertyName("runbookVersion")]
+    public int RunbookVersion { get; set; }
+
+    [JsonPropertyName("batchId")]
+    public int BatchId { get; set; }
+
+    [JsonPropertyName("stepName")]
+    public string StepName { get; set; } = string.Empty;
+
+    [JsonPropertyName("dispatchedAt")]
+    public DateTime DispatchedAt { get; set; }
+}

--- a/src/automation/shared/MaToolkit.Automation.Shared/Services/IServiceBusPublisher.cs
+++ b/src/automation/shared/MaToolkit.Automation.Shared/Services/IServiceBusPublisher.cs
@@ -9,4 +9,5 @@ public interface IServiceBusPublisher
     Task PublishMemberAddedAsync(MemberAddedMessage message);
     Task PublishMemberRemovedAsync(MemberRemovedMessage message);
     Task PublishPollCheckAsync(PollCheckMessage message);
+    Task PublishDispatchTimeoutAsync(DispatchTimeoutMessage message);
 }

--- a/src/automation/shared/MaToolkit.Automation.Shared/Services/Repositories/IInitExecutionRepository.cs
+++ b/src/automation/shared/MaToolkit.Automation.Shared/Services/Repositories/IInitExecutionRepository.cs
@@ -10,6 +10,7 @@ public interface IInitExecutionRepository
     Task<IEnumerable<InitExecutionRecord>> GetByBatchAsync(int batchId);
     Task<IEnumerable<InitExecutionRecord>> GetPendingByBatchAsync(int batchId);
     Task<IEnumerable<InitExecutionRecord>> GetPollingStepsDueAsync(DateTime now);
+    Task<IEnumerable<InitExecutionRecord>> GetDispatchedStepsOlderThanAsync(DateTime cutoff);
     Task<int> InsertAsync(InitExecutionRecord record, IDbTransaction? transaction = null);
     Task<bool> SetDispatchedAsync(int id, string jobId);
     Task<bool> SetSucceededAsync(int id, string? resultJson);

--- a/src/automation/shared/MaToolkit.Automation.Shared/Services/Repositories/IStepExecutionRepository.cs
+++ b/src/automation/shared/MaToolkit.Automation.Shared/Services/Repositories/IStepExecutionRepository.cs
@@ -13,6 +13,7 @@ public interface IStepExecutionRepository
     Task<IEnumerable<StepExecutionRecord>> GetPendingByMemberAsync(int batchMemberId);
     Task<IEnumerable<StepExecutionRecord>> GetByPhaseAndMemberAsync(int phaseExecutionId, int batchMemberId);
     Task<IEnumerable<StepExecutionRecord>> GetPollingStepsDueAsync(DateTime now);
+    Task<IEnumerable<StepExecutionRecord>> GetDispatchedStepsOlderThanAsync(DateTime cutoff);
     Task<int> InsertAsync(StepExecutionRecord record, IDbTransaction? transaction = null);
     Task<bool> SetDispatchedAsync(int id, string jobId);
     Task<bool> SetSucceededAsync(int id, string? resultJson);

--- a/src/automation/shared/MaToolkit.Automation.Shared/Services/Repositories/InitExecutionRepository.cs
+++ b/src/automation/shared/MaToolkit.Automation.Shared/Services/Repositories/InitExecutionRepository.cs
@@ -58,6 +58,17 @@ public class InitExecutionRepository : IInitExecutionRepository
             new { Status = StepStatus.Polling, Now = now });
     }
 
+    public async Task<IEnumerable<InitExecutionRecord>> GetDispatchedStepsOlderThanAsync(DateTime cutoff)
+    {
+        using var conn = _db.CreateConnection();
+        return await conn.QueryAsync<InitExecutionRecord>(@"
+            SELECT ie.* FROM init_executions ie
+            JOIN batches b ON ie.batch_id = b.id
+            WHERE ie.status = @Status
+              AND ie.dispatched_at <= @Cutoff",
+            new { Status = StepStatus.Dispatched, Cutoff = cutoff });
+    }
+
     public async Task<int> InsertAsync(InitExecutionRecord record, IDbTransaction? transaction = null)
     {
         var conn = transaction?.Connection ?? _db.CreateConnection();

--- a/src/automation/shared/MaToolkit.Automation.Shared/Services/Repositories/StepExecutionRepository.cs
+++ b/src/automation/shared/MaToolkit.Automation.Shared/Services/Repositories/StepExecutionRepository.cs
@@ -86,6 +86,18 @@ public class StepExecutionRepository : IStepExecutionRepository
             new { Status = StepStatus.Polling, Now = now });
     }
 
+    public async Task<IEnumerable<StepExecutionRecord>> GetDispatchedStepsOlderThanAsync(DateTime cutoff)
+    {
+        using var conn = _db.CreateConnection();
+        return await conn.QueryAsync<StepExecutionRecord>(@"
+            SELECT se.* FROM step_executions se
+            JOIN phase_executions pe ON se.phase_execution_id = pe.id
+            JOIN batches b ON pe.batch_id = b.id
+            WHERE se.status = @Status
+              AND se.dispatched_at <= @Cutoff",
+            new { Status = StepStatus.Dispatched, Cutoff = cutoff });
+    }
+
     public async Task<int> InsertAsync(StepExecutionRecord record, IDbTransaction? transaction = null)
     {
         var conn = transaction?.Connection ?? _db.CreateConnection();

--- a/src/automation/shared/MaToolkit.Automation.Shared/Services/ServiceBusPublisher.cs
+++ b/src/automation/shared/MaToolkit.Automation.Shared/Services/ServiceBusPublisher.cs
@@ -58,6 +58,14 @@ public class ServiceBusPublisher : IServiceBusPublisher
             message.StepExecutionId, message.PollCount);
     }
 
+    public async Task PublishDispatchTimeoutAsync(DispatchTimeoutMessage message)
+    {
+        await SendMessageAsync(message, message.MessageType);
+        _logger.LogWarning(
+            "Published dispatch-timeout for step execution {StepExecutionId} (step {StepName}, dispatched at {DispatchedAt})",
+            message.StepExecutionId, message.StepName, message.DispatchedAt);
+    }
+
     private async Task SendMessageAsync<T>(T payload, string messageType)
     {
         await using var sender = _client.CreateSender(_topicName);


### PR DESCRIPTION
Adds a dispatch timeout mechanism so steps stuck in dispatched status (worker crashed, never sent results) are automatically failed after 30 minutes.

- Scheduler checks for stuck dispatched steps/inits every 5 min, publishes dispatch-timeout message
- Orchestrator marks step failed, cascades through normal failure path
- Race-safe: skips if result arrived between detection and processing

**Shared Library**
- Add `DispatchTimeout` constant to `MessageTypes`
- Create `DispatchTimeoutMessage` model
- Add `GetDispatchedStepsOlderThanAsync` (DateTime cutoff) to step and init execution repositories
- Add `PublishDispatchTimeoutAsync` to Service Bus publisher

**Orchestrator**
- Create `DispatchTimeoutHandler` with step/init timeout paths
- Wire dispatch-timeout case into `OrchestratorEventFunction` switch
- Register in DI

**Scheduler**
- Add `DispatchTimeoutMinutes` setting (default: 30)
- Create `DispatchTimeoutChecker` service
- Wire into `SchedulerTimerFunction` after polling check
- Register in DI

**Testing**
- 12 new tests, 173 total passing. No schema/infra/config changes.

Closes #42 